### PR TITLE
Add remaining p1 cli tests

### DIFF
--- a/tests/validation/Dockerfile.v3api
+++ b/tests/validation/Dockerfile.v3api
@@ -5,6 +5,7 @@ ENV WORKSPACE /src/rancher-validation
 WORKDIR $WORKSPACE
 ENV PYTHONPATH /src/rancher-validation
 ARG RKE_VERSION=v1.0.2
+ARG CLI_VERSION=v2.3.2
 
 COPY [".", "$WORKSPACE"]
 
@@ -14,6 +15,10 @@ RUN wget https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERS
     wget https://github.com/rancher/rke/releases/download/$RKE_VERSION/rke_linux-amd64 && \
     mv rke_linux-amd64 /bin/rke && \
     chmod +x /bin/rke && \
+    wget https://github.com/rancher/cli/releases/download/$CLI_VERSION/rancher-linux-amd64-$CLI_VERSION.tar.gz && \
+    tar -x -f rancher-linux-amd64-$CLI_VERSION.tar.gz && \
+    mv rancher-$CLI_VERSION/rancher /bin/rancherctl && \
+    chmod +x /bin/rancherctl && \
     wget https://get.helm.sh/helm-v3.0.2-linux-amd64.tar.gz && \
     tar -x -f helm-v3.0.2-linux-amd64.tar.gz && \
     mv linux-amd64/helm /bin/helm_v3 && \

--- a/tests/validation/tests/v3_api/cli_common.py
+++ b/tests/validation/tests/v3_api/cli_common.py
@@ -1,0 +1,87 @@
+import os
+import logging
+import sys
+import time
+
+from .common import run_command, run_command_with_stderr
+
+logging.basicConfig(stream=sys.stdout,
+                    level=os.environ.get("LOGLEVEL", "INFO"),
+                    format='%(asctime)s - %(filename)s:%(funcName)s'
+                           ':%(lineno)d - [%(levelname)5s]: %(message)s',
+                    datefmt="%H:%M:%S")
+DEFAULT_TIMEOUT = 60
+
+
+class BaseCli:
+    log = logging.getLogger(__name__)
+    DEFAULT_CONTEXT = os.environ.get('DEFAULT_CONTEXT', None)
+
+    @classmethod
+    def run_command(cls, command, expect_error=False):
+        command = "rancherctl {}".format(command)
+        cls.log.debug("run cmd:\t%s", command)
+        if expect_error:
+            result = run_command_with_stderr(command, log_out=False)
+        else:
+            result = run_command(command, log_out=False)
+        cls.log.debug("returns:\t%s", result)
+        return result
+
+    def set_log_level(self, level):
+        self.log.setLevel(level)
+
+    def login(self, url, token, **kwargs):
+        context = kwargs.get("context", self.DEFAULT_CONTEXT)
+        if context is None:
+            raise ValueError("No context supplied for rancher login!")
+        cmd = "login {} --token {} --context {} --skip-verify".format(
+            url, token, context)
+        self.run_command(cmd, expect_error=True)
+
+    def switch_context(self, project_id):
+        self.run_command("context switch {}".format(project_id),
+                         expect_error=True)
+
+    def get_context(self):
+        result = self.run_command("context current")
+        cluster_name = result[8:result.index(" ")].strip()
+        project_name = result[result.index("Project:") + 8:].strip()
+        return cluster_name, project_name
+
+    def get_cluster_by_name(self, name):
+        for c in self.get_clusters():
+            if c["name"] == name:
+                return c
+
+    def get_current_cluster(self):
+        for c in self.get_clusters():
+            if c["current"]:
+                return c
+
+    def get_clusters(self):
+        result = self.run_command("clusters ls --format '{{.Cluster.ID}}"
+                                  "|{{.Cluster.Name}}|{{.Current}}|{{.Cluster.UUID}}'")
+        clusters = []
+        for c in result.splitlines():
+            c = c.split("|")
+            cluster = {
+                "id": c[0],
+                "name": c[1],
+                "current": c[2] == "*",
+                "uuid": c[3]
+            }
+            clusters.append(cluster)
+        return clusters
+
+    def wait_for_ready(self, command, val_to_check, **kwargs):
+        timeout = kwargs.get("timeout", DEFAULT_TIMEOUT)
+        condition_func = kwargs.get("condition_func",
+                                    lambda val, l: val in l.splitlines())
+        done = False
+        start_time = time.time()
+        while not done and time.time() - start_time < timeout:
+            result = self.run_command(command)
+            if condition_func(val_to_check, result):
+                done = True
+        return done

--- a/tests/validation/tests/v3_api/cli_common.py
+++ b/tests/validation/tests/v3_api/cli_common.py
@@ -74,6 +74,19 @@ class BaseCli:
             clusters.append(cluster)
         return clusters
 
+    def inspect(self, resource_type, resource_id, **kwargs):
+        resource_format = kwargs.get("format", "{{.id}}")
+        result = self.run_command("inspect --type {} --format '{}' {}".format(
+            resource_type, resource_format, resource_id))
+        return result.strip()
+
+    def ps(self):
+        return self.run_command(
+            "ps --format '{{.NameSpace}}|{{.Name}}|{{.Image}}|{{.Scale}}'")
+
+    def kubectl(self, cmd):
+        return self.run_command("kubectl {}".format(cmd))
+
     def wait_for_ready(self, command, val_to_check, **kwargs):
         timeout = kwargs.get("timeout", DEFAULT_TIMEOUT)
         condition_func = kwargs.get("condition_func",

--- a/tests/validation/tests/v3_api/cli_objects.py
+++ b/tests/validation/tests/v3_api/cli_objects.py
@@ -1,0 +1,295 @@
+from .common import get_user_client, random_test_name
+from .cli_common import DEFAULT_TIMEOUT, BaseCli
+
+
+class RancherCli(BaseCli):
+    def __init__(self, url, token, context):
+        self.login(url, token, context=context)
+        self.projects = ProjectCli()
+        self.apps = AppCli()
+        self.mcapps = MultiClusterAppCli()
+        self.catalogs = CatalogCli()
+        self.default_project = self.projects.create_project()
+        self.default_namespace = self.projects.create_namespace(
+            random_test_name("testdefault"))
+        BaseCli.DEFAULT_CONTEXT = self.default_project["id"]
+        self.switch_context(self.DEFAULT_CONTEXT)
+
+    def cleanup(self):
+        self.log.info("Cleaning up created test project: {}".format(
+            self.default_project["name"]))
+        self.switch_context(self.default_project["id"])
+        self.run_command("project delete {}".format(
+            self.default_project["id"]), expect_error=True)
+
+
+class ProjectCli(BaseCli):
+    def __init__(self):
+        self.initial_projects = self.get_current_projects()
+
+    def create_project(self, name=None,
+                       cluster_id=None, use_context=True):
+        if name is None:
+            name = random_test_name("ptest")
+        if cluster_id is None:
+            cluster = self.get_context()[0]
+            cluster_id = self.get_cluster_by_name(cluster)["id"]
+        self.run_command("projects create --cluster {} {}".format(cluster_id,
+                                                                  name))
+        project = None
+        for p in self.get_current_projects():
+            if p["name"] == name:
+                project = p
+                self.log.info("Project '%s' created successfully "
+                              "in cluster '%s'", name, cluster_id)
+                break
+        if project is None:
+            self.log.error("Failed to create project '%s' "
+                           "in cluster '%s'", name, cluster_id)
+            return project
+
+        if use_context:
+            self.log.info("Switching context to newly created project: "
+                          "%s", name)
+            for p in self.get_current_projects():
+                if p["name"] == name:
+                    self.switch_context(p["id"])
+                    break
+        return project
+
+    def delete_project(self, name):
+        self.run_command("projects rm {}".format(name))
+
+    @classmethod
+    def get_current_projects(cls):
+        """This uses the Rancher Python Client to retrieve the current projects
+        as there is not a CLI way to do this without passing stdin at the time
+        of creation (2/13/2020, Rancher v2.3.5).
+        Returns array of dictionaries containing id, name, clusterid, & uuid"""
+        client = get_user_client()
+        projects = client.list_project()
+        current_projects = []
+        for project in projects:
+            p = {
+                "id": project["id"],
+                "name": project["name"],
+                "clusterId": project["clusterId"],
+                "state": project["state"],
+                "uuid": project["uuid"]
+            }
+            current_projects.append(p)
+        return current_projects
+
+    def create_namespace(self, name=None):
+        if name is None:
+            name = random_test_name("nstest")
+        self.run_command("namespace create {}".format(name))
+        return name
+
+    def delete_namespace(self, name):
+        self.run_command("namespace delete {}".format(name))
+
+        self.log.info("Waiting for the namespace to be deleted")
+        deleted = self.wait_for_ready("namespace ls -q", name, condition_func=
+                                      lambda val, l: val not in l.splitlines())
+        return deleted
+
+    def get_namespaces(self):
+        namespaces = self.run_command("namespace ls --format "
+                                      "'{{.Namespace.Name}}"
+                                      "|{{.Namespace.State}}'")
+        return namespaces.splitlines()
+
+    def move_namespace(self, name, project_id):
+        self.run_command("namespace move {} {}".format(name, project_id))
+
+
+class AppCli(BaseCli):
+    def install(self, app_name, namespace, **kwargs):
+        timeout = kwargs.get("timeout", DEFAULT_TIMEOUT)
+        version = kwargs.get("version", None)
+        context = kwargs.get("context", self.DEFAULT_CONTEXT)
+        cmd = "apps install {} --no-prompt -n {}".format(app_name, namespace)
+        if version is not None:
+            cmd = cmd + " --version {}".format(version)
+
+        self.switch_context(context)
+        app = self.run_command(cmd)
+        app = app.split('"')[1].split(" ")[2]
+        self.log.info("App is: {}".format(app))
+
+        self.log.info("Waiting for the app to be created")
+        created = self.wait_for_ready("apps ls --format '{{.App.Name}} "
+                                      "{{.App.State}}' | grep active "
+                                      "| awk '{print $1}'", app,
+                                      timeout=timeout)
+        if not created:
+            self.log.warn("Failed to install app {} within timeout of {} "
+                          "seconds.".format(app_name, timeout))
+        return self.get(app)
+
+    def get(self, app_name):
+        app = self.run_command("apps ls --format '{{.App.Name}}|{{.App.ID}}"
+                               "|{{.App.State}}|{{.Version}}|{{.Template}}' "
+                               "| grep " + app_name)
+        app = app.split("|")
+        return {"name": app[0], "id": app[1],
+                "state": app[2], "version": app[3], "template": app[4]}
+
+    def upgrade(self, app, **kwargs):
+        timeout = kwargs.get("timeout", DEFAULT_TIMEOUT)
+        version = kwargs.get("version", None)
+        if version is None:
+            version = self.run_command("apps st {} | tail -1".format(
+                app["template"]))
+        self.run_command("apps upgrade {} {}".format(app["name"], version))
+
+        self.log.info("Waiting for the app to be upgraded")
+        upgraded = self.wait_for_ready("apps ls --format '{{.App.Name}} "
+                                       "{{.App.State}}' | grep active "
+                                       "| awk '{print $1}'", app["name"])
+        if not upgraded:
+            self.log.warn("Failed to upgrade app {} within timeout of {} "
+                          "seconds.".format(app["name"], timeout))
+        return self.get(app["name"])
+
+    def rollback(self, app, desired_version, **kwargs):
+        timeout = kwargs.get("timeout", DEFAULT_TIMEOUT)
+        # Retrieve non-current versions that match desired version
+        revision = self.run_command(
+            "apps rollback -r %s | grep %s | awk '{print $1}'" %
+            (app["name"], desired_version)).splitlines()[0]
+
+        self.run_command("apps rollback {} {}".format(app["name"], revision))
+
+        self.log.info("Waiting for the app to be rolled back")
+        rolled_back = self.wait_for_ready("apps ls --format '{{.App.Name}} "
+                                          "{{.App.State}}' | grep active "
+                                          "| awk '{print $1}'", app["name"])
+        if not rolled_back:
+            self.log.warn("Failed to rollback app {} within timeout of {} "
+                          "seconds.".format(app["name"], timeout))
+        return self.get(app["name"])
+
+    def delete(self, app, **kwargs):
+        timeout = kwargs.get("timeout", DEFAULT_TIMEOUT)
+        self.run_command("apps delete {}".format(app["name"]))
+
+        self.log.info("Waiting for the app to be deleted")
+        deleted = self.wait_for_ready("apps ls -q", app["name"],
+                                      timeout=timeout, condition_func=
+                                      lambda val, l: val not in l.splitlines())
+        return deleted
+
+
+class MultiClusterAppCli(BaseCli):
+    def install(self, template_name, **kwargs):
+        timeout = kwargs.get("timeout", DEFAULT_TIMEOUT)
+        version = kwargs.get("version", None)
+        targets = kwargs.get("targets", [self.DEFAULT_CONTEXT])
+        values = kwargs.get("values", None)
+        role = kwargs.get("role", "project-member")
+        cmd = "mcapps install {} --no-prompt --role {}".format(template_name, role)
+        for t in targets:
+            cmd += " --target {}".format(t)
+        if version is not None:
+            cmd += " --version {}".format(version)
+        if values is not None:
+            for k, v in values.items():
+                cmd += " --set {}={}".format(k, v)
+
+        app = self.run_command(cmd)
+        app = app.split('"')[1]
+        self.log.info("Multi-Cluster App is: {}".format(app))
+
+        self.log.info("Waiting for the multi-cluster app to be created")
+        created = self.wait_for_ready("mcapps ls --format '{{.App.Name}} "
+                                      "{{.App.State}}' | grep active "
+                                      "| awk '{print $1}'", app,
+                                      timeout=timeout)
+        if not created:
+            self.log.warn("Failed to install multi-cluster app {} within "
+                          "timeout of {} seconds.".format(
+                            template_name, timeout))
+        return self.get(app)
+
+    def get(self, app_name):
+        app = self.run_command("mcapps ls --format '{{.App.Name}}|{{.App.ID}}"
+                               "|{{.App.State}}|{{.Version}}|{{.Targets}}"
+                               "|{{.App.TemplateVersionID}}' "
+                               "| grep " + app_name)
+        app = app.split("|")
+
+        revision = self.run_command("mcapps rollback -r %s | grep '*' | awk "
+                                    "'{print $2}'" % app_name).splitlines()[0]
+
+        return {"name": app[0], "id": app[1], "state": app[2],
+                "version": app[3], "targets": app[4].split(","),
+                "template": app[5][:-(len(app[3]) + 1)], "revision": revision}
+
+    def upgrade(self, app, **kwargs):
+        timeout = kwargs.get("timeout", DEFAULT_TIMEOUT)
+        version = kwargs.get("version", None)
+        if version is None:
+            version = self.run_command("mcapps st {} | tail -1".format(
+                app["template"]))
+        self.run_command("mcapps upgrade {} {}".format(app["name"], version))
+
+        self.log.info("Waiting for the multi-cluster app to be upgraded")
+        upgraded = self.wait_for_ready("mcapps ls --format '{{.App.Name}} "
+                                       "{{.App.State}}' | grep active "
+                                       "| awk '{print $1}'", app["name"])
+        if not upgraded:
+            self.log.warn("Failed to upgrade multi-cluster app {} within "
+                          "timeout of {} seconds.".format(
+                            app["name"], timeout))
+        return self.get(app["name"])
+
+    def rollback(self, app_name, revision, **kwargs):
+        timeout = kwargs.get("timeout", DEFAULT_TIMEOUT)
+        self.run_command("mcapps rollback {} {}".format(app_name, revision))
+
+        self.log.info("Waiting for the multi-cluster app to be rolled back")
+        rolled_back = self.wait_for_ready("mcapps ls --format '{{.App.Name}} "
+                                          "{{.App.State}}' | grep active "
+                                          "| awk '{print $1}'", app_name)
+        if not rolled_back:
+            self.log.warn("Failed to rollback multi-cluster app {} within "
+                          "timeout of {} seconds.".format(app_name, timeout))
+        return self.get(app_name)
+
+    def delete(self, app, **kwargs):
+        timeout = kwargs.get("timeout", DEFAULT_TIMEOUT)
+        self.run_command("mcapps delete {}".format(app["name"]))
+
+        self.log.info("Waiting for the app to be deleted")
+        deleted = self.wait_for_ready("mcapps ls -q", app["name"],
+                                      timeout=timeout, condition_func=
+                                      lambda val, l: val not in l.splitlines())
+        return deleted
+
+
+class CatalogCli(BaseCli):
+    def add(self, url, **kwargs):
+        branch = kwargs.get("branch", None)
+        catalog_name = random_test_name("ctest")
+        cmd = "catalog add {} {}".format(catalog_name, url)
+        if branch is not None:
+            cmd = cmd + " --branch " + branch
+        self.run_command(cmd)
+        return self.get(catalog_name)
+
+    def delete(self, name):
+        self.run_command("catalog delete " + name)
+        deleted = self.get(name) is None
+        return deleted
+
+    def get(self, name):
+        catalog = self.run_command("catalog ls --format '{{.Catalog.Name}}"
+                                   "|{{.Catalog.ID}}|{{.Catalog.URL}}"
+                                   "|{{.Catalog.Branch}}' | grep " + name)
+        if catalog is None:
+            return None
+        catalog = catalog.split("|")
+        return {"name": catalog[0], "id": catalog[1],
+                "url": catalog[2], "branch": catalog[3]}

--- a/tests/validation/tests/v3_api/cli_objects.py
+++ b/tests/validation/tests/v3_api/cli_objects.py
@@ -1,3 +1,6 @@
+import os
+import subprocess
+
 from .common import get_user_client, random_test_name
 from .cli_common import DEFAULT_TIMEOUT, BaseCli
 
@@ -9,6 +12,8 @@ class RancherCli(BaseCli):
         self.apps = AppCli()
         self.mcapps = MultiClusterAppCli()
         self.catalogs = CatalogCli()
+        self.clusters = ClusterCli()
+        self.nodes = NodeCli()
         self.default_project = self.projects.create_project()
         self.default_namespace = self.projects.create_namespace(
             random_test_name("testdefault"))
@@ -24,9 +29,6 @@ class RancherCli(BaseCli):
 
 
 class ProjectCli(BaseCli):
-    def __init__(self):
-        self.initial_projects = self.get_current_projects()
-
     def create_project(self, name=None,
                        cluster_id=None, use_context=True):
         if name is None:
@@ -119,6 +121,11 @@ class AppCli(BaseCli):
         self.log.info("App is: {}".format(app))
 
         self.log.info("Waiting for the app to be created")
+        # Wait for app to be "deploying"
+        self.wait_for_ready("apps ls --format '{{.App.Name}} {{.App.State}}' "
+                            "| grep deploying | awk '{print $1}'", app,
+                            timeout=timeout)
+        # Wait for app to be "active"
         created = self.wait_for_ready("apps ls --format '{{.App.Name}} "
                                       "{{.App.State}}' | grep active "
                                       "| awk '{print $1}'", app,
@@ -145,6 +152,10 @@ class AppCli(BaseCli):
         self.run_command("apps upgrade {} {}".format(app["name"], version))
 
         self.log.info("Waiting for the app to be upgraded")
+        # Wait for app to be "deploying"
+        self.wait_for_ready("apps ls --format '{{.App.Name}} {{.App.State}}' "
+                            "| grep deploying | awk '{print $1}'", app["name"])
+        # Wait for app to be "active"
         upgraded = self.wait_for_ready("apps ls --format '{{.App.Name}} "
                                        "{{.App.State}}' | grep active "
                                        "| awk '{print $1}'", app["name"])
@@ -163,6 +174,10 @@ class AppCli(BaseCli):
         self.run_command("apps rollback {} {}".format(app["name"], revision))
 
         self.log.info("Waiting for the app to be rolled back")
+        # Wait for app to be "deploying"
+        self.wait_for_ready("apps ls --format '{{.App.Name}} {{.App.State}}' "
+                            "| grep deploying | awk '{print $1}'", app["name"])
+        # Wait for app to be "active"
         rolled_back = self.wait_for_ready("apps ls --format '{{.App.Name}} "
                                           "{{.App.State}}' | grep active "
                                           "| awk '{print $1}'", app["name"])
@@ -201,7 +216,11 @@ class MultiClusterAppCli(BaseCli):
         app = self.run_command(cmd)
         app = app.split('"')[1]
         self.log.info("Multi-Cluster App is: {}".format(app))
-
+        # Wait for multi-cluster app to be "deploying"
+        self.wait_for_ready("mcapps ls --format '{{.App.Name}} {{.App.State}}'"
+                            " | grep deploying | awk '{print $1}'",
+                            app, timeout=timeout)
+        # Wait for multi-cluster app to be "active"
         self.log.info("Waiting for the multi-cluster app to be created")
         created = self.wait_for_ready("mcapps ls --format '{{.App.Name}} "
                                       "{{.App.State}}' | grep active "
@@ -236,6 +255,11 @@ class MultiClusterAppCli(BaseCli):
         self.run_command("mcapps upgrade {} {}".format(app["name"], version))
 
         self.log.info("Waiting for the multi-cluster app to be upgraded")
+        # Wait for multi-cluster app to be "deploying"
+        self.wait_for_ready("mcapps ls --format '{{.App.Name}} {{.App.State}}'"
+                            " | grep deploying | awk '{print $1}'",
+                            app["name"], timeout=timeout)
+        # Wait for multi-cluster app to be "active"
         upgraded = self.wait_for_ready("mcapps ls --format '{{.App.Name}} "
                                        "{{.App.State}}' | grep active "
                                        "| awk '{print $1}'", app["name"])
@@ -250,6 +274,11 @@ class MultiClusterAppCli(BaseCli):
         self.run_command("mcapps rollback {} {}".format(app_name, revision))
 
         self.log.info("Waiting for the multi-cluster app to be rolled back")
+        # Wait for multi-cluster app to be "deploying"
+        self.wait_for_ready("mcapps ls --format '{{.App.Name}} {{.App.State}}'"
+                            " | grep deploying | awk '{print $1}'",
+                            app_name, timeout=timeout)
+        # Wait for multi-cluster app to be "active"
         rolled_back = self.wait_for_ready("mcapps ls --format '{{.App.Name}} "
                                           "{{.App.State}}' | grep active "
                                           "| awk '{print $1}'", app_name)
@@ -293,3 +322,46 @@ class CatalogCli(BaseCli):
         catalog = catalog.split("|")
         return {"name": catalog[0], "id": catalog[1],
                 "url": catalog[2], "branch": catalog[3]}
+
+
+class ClusterCli(BaseCli):
+    def delete(self, c_id):
+        self.run_command("clusters delete {}".format(c_id))
+
+        self.log.info("Waiting for the cluster to be deleted")
+        deleted = self.wait_for_ready("cluster ls -q", c_id, condition_func=
+                                      lambda val, l: val not in l.splitlines())
+        return deleted
+
+
+class NodeCli(BaseCli):
+    def get(self):
+        result = self.run_command(
+            "nodes ls --format '{{.Name}}|{{.Node.IPAddress}}'").splitlines()
+        nodes = []
+        for n in result:
+            nodes.append({
+                "name": n.split("|")[0],
+                "ip": n.split("|")[1]
+            })
+        return nodes
+
+    def ssh(self, node, cmd):
+        known = False
+        self.log.debug("Determining if host is already known")
+        known_hosts = os.path.expanduser("~/.ssh/known_hosts")
+        with open(known_hosts) as file:
+            for line in file:
+                if node["ip"] in line:
+                    known = True
+                    break
+        if not known:
+            try:
+                self.log.debug("Storing ecdsa key in known hosts")
+                subprocess.run("ssh-keyscan -t ecdsa {} "
+                               ">> ~/.ssh/known_hosts".format(node["ip"]),
+                               shell=True, stderr=subprocess.PIPE)
+            except subprocess.CalledProcessError as e:
+                self.log.info("Error storing ecdsa key! Result: %s", e.stderr)
+        ssh_result = self.run_command('ssh {} "{}"'.format(node["name"], cmd))
+        return ssh_result

--- a/tests/validation/tests/v3_api/scripts/build.sh
+++ b/tests/validation/tests/v3_api/scripts/build.sh
@@ -6,6 +6,7 @@ set -eu
 DEBUG="${DEBUG:-false}"
 RKE_VERSION="${RKE_VERSION:-v1.0.2}"
 KUBECTL_VERSION="${KUBECTL_VERSION:-v1.16.6}"
+CLI_VERSION="${CLI_VERSION:-v2.3.2}"
 
 if [ "false" != "${DEBUG}" ]; then
     echo "Environment:"
@@ -16,7 +17,7 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../../" && pwd )"
 
 count=0
 while [[ 3 -gt $count ]]; do    
-    docker build -q -f Dockerfile.v3api --build-arg RKE_VERSION=$RKE_VERSION --build-arg KUBECTL_VERSION=$KUBECTL_VERSION -t rancher-validation-${JOB_NAME}${BUILD_NUMBER} .
+    docker build -q -f Dockerfile.v3api --build-arg CLI_VERSION=$CLI_VERSION --build-arg RKE_VERSION=$RKE_VERSION --build-arg KUBECTL_VERSION=$KUBECTL_VERSION -t rancher-validation-${JOB_NAME}${BUILD_NUMBER} .
 
     if [[ $? -eq 0 ]]; then break; fi
     count=$(($count + 1))

--- a/tests/validation/tests/v3_api/scripts/configure.sh
+++ b/tests/validation/tests/v3_api/scripts/configure.sh
@@ -5,7 +5,7 @@ set -eu
 
 DEBUG="${DEBUG:-false}"
 
-env | egrep '^(CATTLE_|ADMIN|USER|DO|RANCHER_|AWS_|DEBUG|DEFAULT_|OS_|DOCKER_|CLOUD_|KUBE|BUILD_NUMBER|AZURE).*\=.+' | sort > .env
+env | egrep '^(CATTLE_|ADMIN|USER|DO|RANCHER_|AWS_|DEBUG|LOGLEVEL|DEFAULT_|OS_|DOCKER_|CLOUD_|KUBE|BUILD_NUMBER|AZURE).*\=.+' | sort > .env
 
 if [ "false" != "${DEBUG}" ]; then
     cat .env

--- a/tests/validation/tests/v3_api/test_cli.py
+++ b/tests/validation/tests/v3_api/test_cli.py
@@ -1,0 +1,206 @@
+import ast
+import os
+import pytest
+
+from .test_rke_cluster_provisioning import (create_and_validate_custom_host,
+                                            cluster_cleanup)
+from .cli_objects import RancherCli
+from .common import (ADMIN_TOKEN, USER_TOKEN, CATTLE_TEST_URL, CLUSTER_NAME,
+                     AWS_ACCESS_KEY_ID, get_admin_client, get_user_client,
+                     get_user_client_and_cluster)
+
+if_test_multicluster = pytest.mark.skipif(
+    not AWS_ACCESS_KEY_ID or ast.literal_eval(
+        os.environ.get('RANCHER_SKIP_MULTICLUSTER', "False")),
+    reason='Multi-Cluster tests are skipped in the interest of time/cost.')
+
+
+def test_context_switching(rancher_cli: RancherCli):
+    rancher_cli.log.info("Testing Context Switching")
+    clusters = rancher_cli.get_clusters()
+    client = get_user_client()
+    projects = client.list_project()
+    for project in projects:
+        rancher_cli.switch_context(project['id'])
+        cluster_name, project_name = rancher_cli.get_context()
+        assert any(cluster["id"] == project['clusterId']
+                   and cluster["name"] == cluster_name for cluster in clusters)
+        assert project_name == project['name']
+
+
+def test_project_manipulation(remove_cli_resource, rancher_cli: RancherCli):
+    rancher_cli.log.info("Testing Creating and Deleting Projects")
+    initial_projects = rancher_cli.projects.get_current_projects()
+    project = rancher_cli.projects.create_project(use_context=False)
+    remove_cli_resource("project", project["id"])
+    assert project is not None
+    assert len(initial_projects) == len(
+        rancher_cli.projects.get_current_projects()) - 1
+
+    rancher_cli.projects.delete_project(project["name"])
+    assert len(initial_projects) == len(
+        rancher_cli.projects.get_current_projects())
+
+
+def test_namespace_manipulation(remove_cli_resource, rancher_cli: RancherCli):
+    rancher_cli.log.info("Testing Creating, Deleting, and Moving Namespaces")
+    p1 = rancher_cli.projects.create_project()
+    remove_cli_resource("project", p1["id"])
+    namespace = rancher_cli.projects.create_namespace()
+    remove_cli_resource("namespace", namespace)
+    assert len(rancher_cli.projects.get_namespaces()) == 1
+    assert "{}|active".format(
+        namespace) in rancher_cli.projects.get_namespaces()
+
+    p2 = rancher_cli.projects.create_project(use_context=False)
+    remove_cli_resource("project", p2["id"])
+    rancher_cli.projects.move_namespace(namespace, p2["id"])
+    assert len(rancher_cli.projects.get_namespaces()) == 0
+    rancher_cli.projects.switch_context(p2["id"])
+    assert len(rancher_cli.projects.get_namespaces()) == 1
+    assert "{}|active".format(
+        namespace) in rancher_cli.projects.get_namespaces()
+
+    deleted = rancher_cli.projects.delete_namespace(namespace)
+    assert deleted
+
+
+def test_app_management(remove_cli_resource, rancher_cli: RancherCli):
+    rancher_cli.log.info("Testing Install, Upgrade, Rollback, and Delete Apps")
+    initial_app = rancher_cli.apps.install("openebs", "openebs",
+                                           version="1.5.0", timeout=120)
+    assert initial_app["state"] == "active"
+    assert initial_app["version"] == "1.5.0"
+    remove_cli_resource("apps", initial_app["id"])
+    upgraded_app = rancher_cli.apps.upgrade(initial_app, version="1.6.0")
+    assert upgraded_app["state"] == "active"
+    assert upgraded_app["version"] == "1.6.0"
+    rolled_back_app = rancher_cli.apps.rollback(upgraded_app, "1.5.0")
+    assert rolled_back_app["state"] == "active"
+    assert rolled_back_app["version"] == "1.5.0"
+    deleted = rancher_cli.apps.delete(rolled_back_app)
+    assert deleted
+
+
+@if_test_multicluster
+def test_multiclusterapp_management(custom_cluster, remove_cli_resource,
+                                    admin_cli: RancherCli):
+    admin_cli.log.info("Testing Multi-Cluster Apps")
+
+    # Get list of projects to use and ensure that it is 2 or greater
+    client = get_admin_client()
+    projects = client.list_project()
+    targets = []
+    for project in projects:
+        if project["name"] == "Default":
+            admin_cli.switch_context(project['id'])
+            cluster_name, project_name = admin_cli.get_context()
+            if cluster_name in [custom_cluster.name, CLUSTER_NAME]:
+                admin_cli.log.debug("Using cluster: %s", cluster_name)
+                targets.append(project["id"])
+    assert len(targets) > 1
+
+    # Supplying default answers due to issue with multi-cluster app install:
+    # https://github.com/rancher/rancher/issues/25514
+    values = {
+        "analytics.enabled": "true",
+        "defaultImage": "true",
+        "defaultPorts": "true",
+        "ndm.filters.excludePaths": "loop,fd0,sr0,/dev/ram,/dev/dm-,/dev/md",
+        "ndm.filters.excludeVendors": "CLOUDBYT,OpenEBS",
+        "ndm.sparse.count": "0",
+        "ndm.sparse.enabled": "true",
+        "ndm.sparse.path": "/var/openebs/sparse",
+        "ndm.sparse.size":"10737418240", "policies.monitoring.enabled": "true"
+    }
+    initial_app = admin_cli.mcapps.install("openebs", targets=targets,
+                                           role="cluster-owner", values=values,
+                                           version="1.5.0", timeout=120)
+    remove_cli_resource("mcapps", initial_app["name"])
+    assert initial_app["state"] == "active"
+    assert initial_app["version"] == "1.5.0"
+    assert len(initial_app["targets"]) == len(targets)
+    upgraded_app = admin_cli.mcapps.upgrade(initial_app, version="1.6.0",
+                                            timeout=120)
+    assert upgraded_app["state"] == "active"
+    assert upgraded_app["version"] == "1.6.0"
+    assert upgraded_app["id"] == initial_app["id"]
+    rolled_back_app = admin_cli.mcapps.rollback(
+        upgraded_app["name"], initial_app["revision"], timeout=120)
+    assert rolled_back_app["state"] == "active"
+    assert rolled_back_app["version"] == "1.5.0"
+    assert rolled_back_app["id"] == upgraded_app["id"]
+    deleted = admin_cli.mcapps.delete(rolled_back_app)
+    assert deleted
+
+
+def test_catalog(admin_cli: RancherCli):
+    admin_cli.log.info("Testing Creating and Deleting Catalogs")
+    admin_cli.login(CATTLE_TEST_URL, ADMIN_TOKEN)
+    catalog = admin_cli.catalogs.add("https://git.rancher.io/system-charts",
+                                     branch="dev")
+    assert catalog is not None
+    deleted = admin_cli.catalogs.delete(catalog["name"])
+    assert deleted
+
+
+@pytest.fixture(scope='module')
+def custom_cluster(request, rancher_cli):
+    rancher_cli.log.info("Creating cluster in AWS to test CLI actions that "
+                         "require more than one cluster. Please be patient, "
+                         "as this takes some time...")
+    node_roles = [["controlplane"], ["etcd"],
+                  ["worker"], ["worker"], ["worker"]]
+    cluster, aws_nodes = create_and_validate_custom_host(
+        node_roles, random_cluster_name=True)
+
+    def fin():
+        cluster_cleanup(get_user_client(), cluster, aws_nodes)
+    request.addfinalizer(fin)
+    return cluster
+
+
+@pytest.fixture
+def admin_cli(request, rancher_cli) -> RancherCli:
+    """
+       Login occurs at a global scope, so need to ensure we log back in as the
+       user in a finalizer so that future tests have no issues.
+    """
+    rancher_cli.login(CATTLE_TEST_URL, ADMIN_TOKEN)
+
+    def fin():
+        rancher_cli.login(CATTLE_TEST_URL, USER_TOKEN)
+    request.addfinalizer(fin)
+    return rancher_cli
+
+
+@pytest.fixture(scope='module', autouse="True")
+def rancher_cli(request) -> RancherCli:
+    client, cluster = get_user_client_and_cluster()
+    project_id = client.list_project(name='Default',
+                                     clusterId=cluster.id).data[0]["id"]
+    cli = RancherCli(CATTLE_TEST_URL, USER_TOKEN, project_id)
+
+    def fin():
+        cli.cleanup()
+    request.addfinalizer(fin)
+    return cli
+
+
+@pytest.fixture
+def remove_cli_resource(request, rancher_cli):
+    """Remove a resource after a test finishes even if the test fails.
+
+    How to use:
+      pass this function as an argument of your testing function,
+      then call this function with the resource type and its id
+      as arguments after creating any new resource
+    """
+    def _cleanup(resource, r_id):
+        def clean():
+            rancher_cli.switch_context(rancher_cli.DEFAULT_CONTEXT)
+            rancher_cli.log.info("Cleaning up {}: {}".format(resource, r_id))
+            rancher_cli.run_command("{} delete {}".format(resource, r_id),
+                                    expect_error=True)
+        request.addfinalizer(clean)
+    return _cleanup


### PR DESCRIPTION
With this PR, the following p1 scenarios are covered (at least at a high level):
- apps
- catalog
- clusters
- multi-cluster apps
- context
- inspect
- kubectl
- login
- namespace
- projects
- nodes
- ssh